### PR TITLE
Cleanup warnings

### DIFF
--- a/src/plugins/banshee-plugin.vala
+++ b/src/plugins/banshee-plugin.vala
@@ -89,11 +89,6 @@ namespace Synapse
         bool banshee_running = DBusService.get_default ().name_has_owner (BansheePlayerEngine.UNIQUE_NAME);
         return banshee_running ? default_relevancy + MatchScore.INCREMENT_LARGE : default_relevancy;
       }
-
-      public virtual bool action_available ()
-      {
-        return DBusService.get_default ().name_has_owner (BansheePlayerEngine.UNIQUE_NAME);
-      }
     }
 
     private abstract class BansheeControlMatch : ActionMatch

--- a/src/plugins/rhythmbox-plugin.vala
+++ b/src/plugins/rhythmbox-plugin.vala
@@ -96,11 +96,6 @@ namespace Synapse
         bool rb_running = DBusService.get_default ().name_has_owner (RhythmboxPlayer.UNIQUE_NAME);
         return rb_running ? default_relevancy + MatchScore.INCREMENT_LARGE : default_relevancy;
       }
-
-      public virtual bool action_available ()
-      {
-        return DBusService.get_default ().name_has_owner (RhythmboxPlayer.UNIQUE_NAME);
-      }
     }
 
     private abstract class RhythmboxControlMatch : ActionMatch
@@ -181,7 +176,7 @@ namespace Synapse
                                            RhythmboxPlayer.OBJECT_PATH);
 
           player.next ();
-        } 
+        }
         catch (IOError e)
         {
           warning ("Rythmbox is not available.\n%s", e.message);
@@ -207,7 +202,7 @@ namespace Synapse
 
           player.previous ();
           player.previous ();
-        } 
+        }
         catch (IOError e)
         {
           warning ("Rythmbox is not available.\n%s", e.message);
@@ -244,7 +239,7 @@ namespace Synapse
           shell.add_to_queue (uri.uri);
           if (!(player.playback_status == "Playing"))
             player.play ();
-        } 
+        }
         catch (IOError e)
         {
           warning ("Rythmbox is not available.\n%s", e.message);
@@ -282,7 +277,7 @@ namespace Synapse
           if (!(player.playback_status == "Playing"))
             player.play ();
           player.open_uri (uri.uri);
-        } 
+        }
         catch (IOError e)
         {
           warning ("Rythmbox is not available.\n%s", e.message);

--- a/src/plugins/zim-plugin.vala
+++ b/src/plugins/zim-plugin.vala
@@ -159,17 +159,13 @@ namespace Synapse
           );
 
         } else if (info.get_file_type() == FileType.REGULAR && file_name.has_suffix (".txt")) {
-          try {
-            string page = file_name.replace("_", " ").replace(".txt", "");
-            if (prefix != "") {
-              page = "%s:%s".printf(prefix.replace("_", " "), page);
-            }
-
-            var match = new ZimPageMatch(notebook.get_basename (), page);
-            result.append (match);
-          } catch (Error err) {
-            warning ("%s", err.message);
+          string page = file_name.replace("_", " ").replace(".txt", "");
+          if (prefix != "") {
+            page = "%s:%s".printf(prefix.replace("_", " "), page);
           }
+
+          var match = new ZimPageMatch(notebook.get_basename (), page);
+          result.append (match);
         }
       }
       return result;

--- a/src/ui/interfaces.vala
+++ b/src/ui/interfaces.vala
@@ -44,8 +44,8 @@ namespace Synapse.Gui
     public abstract KeyComboConfig key_combo_config { get; construct set; }
     public abstract CategoryConfig category_config { get; construct set; }
 
-    public static const int RESULTS_PER_PAGE = 5;
-    public static const int PARTIAL_RESULT_TIMEOUT = 120;
+    public const int RESULTS_PER_PAGE = 5;
+    public const int PARTIAL_RESULT_TIMEOUT = 120;
 
     /* Events called by View */
 

--- a/src/ui/tile-view/tile-view.vala
+++ b/src/ui/tile-view/tile-view.vala
@@ -130,8 +130,6 @@ namespace UI.Widgets
       return null;
     }
 
-    private bool changing_style = false;
-
     protected override void style_updated ()
     {
       /*if (changing_style) return;

--- a/src/ui/tile-view/tile.vala
+++ b/src/ui/tile-view/tile.vala
@@ -37,7 +37,7 @@ namespace UI.Widgets
 
     public unowned TileView owner { get; set; }
     public AbstractTileObject owned_object { get; private set; }
-    public bool last { get; private set; }
+    public bool last_flag { get; private set; }
 
     public signal void active_changed ();
 
@@ -139,7 +139,7 @@ namespace UI.Widgets
         context.render_background (cr, 0, 0, allocation.width, allocation.height);
       }
 
-      if (!last)
+      if (!last_flag)
       {
         context.save ();
         // this gives us a lighter stroke

--- a/src/ui/widgets-matchlistview.vala
+++ b/src/ui/widgets-matchlistview.vala
@@ -249,8 +249,8 @@ namespace Synapse.Gui
   {
     /* Animation stuffs */
     private uint tid;
-    private static const int ANIM_TIMEOUT = 1000 / 25;
-    private static const int ANIM_STEPS = 180 / ANIM_TIMEOUT;
+    private const int ANIM_TIMEOUT = 1000 / 25;
+    private const int ANIM_STEPS = 180 / ANIM_TIMEOUT;
     public bool animation_enabled {
       get; set; default = true;
     }

--- a/src/ui/widgets-matchlistview.vala
+++ b/src/ui/widgets-matchlistview.vala
@@ -868,7 +868,6 @@ namespace Synapse.Gui
         /* Prepare bg's colors using GtkStyleContext */
         Cairo.Pattern pat = new Cairo.Pattern.linear(0, 0, 0, status.get_allocated_height ());
 
-        Gtk.StateFlags t = this.get_state_flags ();
         /* Prepare and draw top bg's rect */
         ctx.set_source (pat);
         ctx.paint ();

--- a/src/ui/widgets.vala
+++ b/src/ui/widgets.vala
@@ -53,7 +53,7 @@ namespace Synapse.Gui
 
   public class SmartLabel : Gtk.Misc
   {
-    public static const string[] size_to_string = {
+    public const string[] size_to_string = {
       "xx-small",
       "x-small",
       "small",
@@ -73,7 +73,7 @@ namespace Synapse.Gui
       return s;
     }
 
-    protected static const double[] size_to_scale = {
+    protected const double[] size_to_scale = {
       Pango.Scale.XX_SMALL,
       Pango.Scale.X_SMALL,
       Pango.Scale.SMALL,
@@ -115,8 +115,8 @@ namespace Synapse.Gui
     private Pango.EllipsizeMode ellipsize = Pango.EllipsizeMode.NONE;
 
     private uint tid = 0;
-    private static const int INITIAL_TIMEOUT = 1750;
-    private static const int SPACING = 50;
+    private const int INITIAL_TIMEOUT = 1750;
+    private const int SPACING = 50;
     private int offset = 0;
     private bool animate = false;
 


### PR DESCRIPTION
Listed when running `make`

- [x] Fix bug in vala 0.38
- [x] warning: method `Synapse.BansheeActions.BansheeAction.action_available' never used
- [x] rhythmbox-plugin.vala:100.7-100.42: warning: method `Synapse.RhythmboxActions.RhythmboxAction.action_available' never used
- [x] zim-plugin.vala:170.19-172.11: warning: unreachable catch clause detected
- [ ] unhandled error `GLib.Error'
- [ ] Gtk.Stock has been deprecated since 3.10
- [ ] Gdk.Device.grab has been deprecated since 3.20
- [ ] Gdk.Display.get_device_manager has been deprecated since 3.20
- [ ] Gdk.Window.set_background_rgba has been deprecated since 3.22
- [ ] Gtk.Widget.override_background_color has been deprecated since 3.16
- [ ] Gdk.Window.process_all_updates has been deprecated since 3.22
- [ ] Gdk.cairo_create has been deprecated since 3.22
- [ ] Gdk.DeviceManager.get_client_pointer has been deprecated since 3.20
- [ ] Gdk.Device.ungrab has been deprecated since 3.20
- [ ] Gdk.Screen.get_monitor_geometry has been deprecated since 3.22
- [ ] Gdk.Screen.get_monitor_at_point has been deprecated since 3.22